### PR TITLE
Fix issue #14 that a binary value renders invalid SQL.

### DIFF
--- a/src/Shared/DC/ZRDB/sqltest.py
+++ b/src/Shared/DC/ZRDB/sqltest.py
@@ -164,6 +164,9 @@ class SQLTest:
                 if not isinstance(v, StringTypes):
                     v = str(v)
                 v = md.getitem('sql_quote__', 0)(v)
+                # fix https://github.com/zopefoundation/Products.ZSQLMethods/issues/14
+                if isinstance(v, six.binary_type):
+                    v = v.decode('utf-8')
                 # if v.find("\'") >= 0: v="''".(v.split("\'"))
                 # v="'%s'" % v
             vs.append(v)

--- a/src/Shared/DC/ZRDB/sqltest.py
+++ b/src/Shared/DC/ZRDB/sqltest.py
@@ -164,7 +164,7 @@ class SQLTest:
                 if not isinstance(v, StringTypes):
                     v = str(v)
                 v = md.getitem('sql_quote__', 0)(v)
-                # fix #issue 14
+                # fix issue #14
                 if isinstance(v, six.binary_type):
                     v = v.decode('utf-8')
                 # if v.find("\'") >= 0: v="''".(v.split("\'"))

--- a/src/Shared/DC/ZRDB/sqltest.py
+++ b/src/Shared/DC/ZRDB/sqltest.py
@@ -164,7 +164,7 @@ class SQLTest:
                 if not isinstance(v, StringTypes):
                     v = str(v)
                 v = md.getitem('sql_quote__', 0)(v)
-                # fix https://github.com/zopefoundation/Products.ZSQLMethods/issues/14
+                # fix #issue 14
                 if isinstance(v, six.binary_type):
                     v = v.decode('utf-8')
                 # if v.find("\'") >= 0: v="''".(v.split("\'"))


### PR DESCRIPTION
This fix do not address the question why a binary value is created for 'Y' in <dtml-sqltest> but not in <dtml-sqlvar>.
Nevertheless the fix at this position basically is a check for an invalid return value, makes the code more stable and fixes the issue.