### PR TITLE
Drop webdav support as it is gone from zope master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 .coverage*
 coverage.xml
 default.profraw
+pyvenv.cfg
 *.bak
 *.dll
 *.pyc

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.0.9 (unreleased)
 ------------------
 
+- fix ImportError under Zope 5 due to moved dependencies
+  (`#19 <https://github.com/zopefoundation/Products.ZSQLMethods/pull/19>`_)
+
 
 3.0.8 (2019-08-05)
 ------------------

--- a/src/Shared/DC/ZRDB/DA.py
+++ b/src/Shared/DC/ZRDB/DA.py
@@ -35,7 +35,6 @@ from DocumentTemplate import HTML
 from DocumentTemplate.html_quote import html_quote
 from DocumentTemplate.security import RestrictedDTML
 from ExtensionClass import Base
-from OFS import bbb
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item
 from Persistence import Persistent
@@ -49,14 +48,6 @@ from .Results import Results
 from .sqlgroup import SQLGroup
 from .sqltest import SQLTest
 from .sqlvar import SQLVar
-
-
-if bbb.HAS_ZSERVER:
-    from webdav.Resource import Resource
-    from webdav.Lockable import ResourceLockedError
-else:
-    Resource = bbb.Resource
-    from zExceptions import ResourceLockedError
 
 
 def _getPath(home, prefix, name, suffixes):
@@ -212,8 +203,7 @@ class DA(BaseQuery,
          Implicit,
          Persistent,
          RoleManager,
-         Item,
-         Resource):
+         Item):
     """Database Adapter base class"""
 
     security = ClassSecurityInfo()
@@ -303,9 +293,6 @@ class DA(BaseQuery,
         if SUBMIT in self._size_changes:
             return self._er(title, connection_id, arguments, template,
                             SUBMIT, dtpref_cols, dtpref_rows, REQUEST)
-
-        if self.wl_isLocked():
-            raise ResourceLockedError('SQL Method is locked via WebDAV')
 
         self.title = str(title)
         self.connection_id = str(connection_id)

--- a/src/Shared/DC/ZRDB/DA.py
+++ b/src/Shared/DC/ZRDB/DA.py
@@ -227,7 +227,8 @@ class DA(BaseQuery,
          Implicit,
          Persistent,
          RoleManager,
-         Item):
+         Item,
+         Resource):
     """Database Adapter base class"""
 
     security = ClassSecurityInfo()

--- a/src/Shared/DC/ZRDB/DA.py
+++ b/src/Shared/DC/ZRDB/DA.py
@@ -50,6 +50,30 @@ from .sqltest import SQLTest
 from .sqlvar import SQLVar
 
 
+try:
+    from OFS import bbb
+except ImportError:
+    bbb = None
+
+
+if bbb is not None and bbb.HAS_ZSERVER:
+    from webdav.Resource import Resource
+    from webdav.Lockable import ResourceLockedError
+else:
+    from zExceptions import ResourceLockedError
+
+    class Resource:
+        def dav__init(self, request, response):
+            pass
+
+        def dav__validate(self, object, methodname, REQUEST):
+            pass
+
+        def dav__simpleifhandler(self, request, response, method='PUT',
+                                 col=0, url=None, refresh=0):
+            pass
+
+
 def _getPath(home, prefix, name, suffixes):
 
     dir = os.path.join(home, prefix)
@@ -293,6 +317,9 @@ class DA(BaseQuery,
         if SUBMIT in self._size_changes:
             return self._er(title, connection_id, arguments, template,
                             SUBMIT, dtpref_cols, dtpref_rows, REQUEST)
+
+        if self.wl_isLocked():
+            raise ResourceLockedError('SQL Method is locked via WebDAV')
 
         self.title = str(title)
         self.connection_id = str(connection_id)


### PR DESCRIPTION
Not sure this is the right way -  but it did allow zope to load again with this installed on the current master.

What do you think?

As far as I know this should make it compatible again with the changes introduced in https://github.com/zopefoundation/Zope/issues/592