### PR TITLE
Depend on DocumentTemplate 2.13.5+ to do SQL quoting.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 2.13.6 (unreleased)
 -------------------
 
-- TBD
+- Depend on ``DocumentTemplate`` 2.13.5+ to do SQL quoting.
+  Note: because of that dependency it might be better to use Zope 2.13,
+  although technically we only require 2.12 minimum.
 
 2.13.5 (2016-11-10)
 -------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,6 @@
 [buildout]
 extends = https://raw.githubusercontent.com/zopefoundation/Zope/2.13/version_ranges.cfg
+index = https://pypi.org/simple/
 develop = .
 parts = interpreter test
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'Zope2 > 2.12.8',
         # These are only available with Zope >= 2.13.0a1
         # 'AccessControl',
-        # 'DocumentTemplate',
+        'DocumentTemplate >= 2.13.5',
         # 'zExceptions',
     ],
     include_package_data=True,

--- a/src/Shared/DC/ZRDB/Connection.py
+++ b/src/Shared/DC/ZRDB/Connection.py
@@ -28,6 +28,7 @@ from App.Dialogs import MessageDialog
 from App.special_dtml import DTMLFile
 from DateTime.DateTime import DateTime
 from DocumentTemplate import HTML
+from DocumentTemplate.DT_Var import sql_quote
 from OFS.SimpleItem import Item
 from Persistence import Persistent
 from zExceptions import BadRequest
@@ -169,7 +170,7 @@ class Connection(Persistent,
                               'manage_close_connection')
     def manage_close_connection(self, REQUEST=None):
         " "
-        try: 
+        try:
             if hasattr(self,'_v_database_connection'):
                 self._v_database_connection.close()
         except:
@@ -214,10 +215,7 @@ class Connection(Persistent,
         return self
 
     def sql_quote__(self, v):
-        if string.find(v,"\'") >= 0:
-            v = string.join(string.split(v,"\'"),"''")
-        if string.find(v,"\x00") >= 0:
-            v = string.join(string.split(v,"\x00"), "")
+        v = sql_quote(v)
         return "'%s'" % v
 
 InitializeClass(Connection)

--- a/src/Shared/DC/ZRDB/tests/test_connection.py
+++ b/src/Shared/DC/ZRDB/tests/test_connection.py
@@ -39,7 +39,7 @@ class ConnectionTests(unittest.TestCase):
         self.assertFalse(hasattr(conn2, '_connected_to'))
 
     def test_sql_quote___miss(self):
-        TO_QUOTE = "no quoting required"
+        TO_QUOTE = 'no quoting required'
         conn = self._makeOne('conn', '', 'conn string')
         self.assertEqual(conn.sql_quote__(TO_QUOTE), "'%s'" % TO_QUOTE)
 
@@ -49,11 +49,39 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(conn.sql_quote__(TO_QUOTE),
                          "'w''embedded apostrophe'")
 
+    def test_sql_quote___embedded_backslash(self):
+        TO_QUOTE = 'embedded \\backslash'
+        conn = self._makeOne('conn', '', 'conn string')
+        self.assertEqual(conn.sql_quote__(TO_QUOTE),
+                         "'embedded \\\\backslash'")
+        # Show for good measure that the seeming four backslashes
+        # are really two, when you look at the raw string.
+        self.assertEqual(conn.sql_quote__(TO_QUOTE),
+                         r"'embedded \\backslash'")
+
+    def test_sql_quote___embedded_double_quote(self):
+        TO_QUOTE = 'embedded "double quote'
+        conn = self._makeOne('conn', '', 'conn string')
+        self.assertEqual(conn.sql_quote__(TO_QUOTE),
+                         r"'embedded \"double quote'")
+
     def test_sql_quote___embedded_null(self):
         TO_QUOTE = "w'embedded apostrophe and \x00null"
         conn = self._makeOne('conn', '', 'conn string')
         self.assertEqual(conn.sql_quote__(TO_QUOTE),
                          "'w''embedded apostrophe and null'")
+
+        # This is another version of a nul character.
+        TO_QUOTE = 'embedded other \x1anull'
+        conn = self._makeOne('conn', '', 'conn string')
+        self.assertEqual(conn.sql_quote__(TO_QUOTE),
+                         "'embedded other null'")
+
+    def test_sql_quote___embedded_carriage_return(self):
+        TO_QUOTE = "w'embedded carriage\rreturn"
+        conn = self._makeOne('conn', '', 'conn string')
+        self.assertEqual(conn.sql_quote__(TO_QUOTE),
+                         "'w''embedded carriagereturn'")
 
 
 def test_suite():


### PR DESCRIPTION
Note: because of that dependency it might be better to use Zope 2.13,
although technically we only require 2.12 minimum.

The test file was copied without change from the master branch, with the latest fixes.

(Note: Products.PythonScripts will need similar fixes, but I will leave that for another day.)