### PR TITLE
Fix how we join a transaction.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.5 (unreleased)
 ----------------
 
+- Fixed incompatibility with ``transaction`` version 3.
+  (`#23 <https://github.com/zopefoundation/Products.ZSQLMethods/pull/23>`_)
+
 
 3.4 (2020-02-13)
 ----------------

--- a/src/Shared/DC/ZRDB/THUNK.py
+++ b/src/Shared/DC/ZRDB/THUNK.py
@@ -20,7 +20,6 @@ from transaction.interfaces import TransactionFailedError
 from zope.interface import implementer
 
 from .TM import TM
-from .TM import Surrogate
 
 
 LOG = logging.getLogger('Products.ZSQLMethods')
@@ -37,7 +36,7 @@ class THUNKED_TM(TM):
             thunk_lock.acquire()
 
             try:
-                self.transaction_manager.get().join(Surrogate(self))
+                self.transaction_manager.get().join(self)
             except TransactionFailedError:
                 LOG.error('Failed to join transaction: ', exc_info=True)
                 # No need to raise here, the transaction is already

--- a/src/Shared/DC/ZRDB/THUNK.py
+++ b/src/Shared/DC/ZRDB/THUNK.py
@@ -11,32 +11,46 @@
 #
 ##############################################################################
 
+import logging
+
 from six.moves._thread import allocate_lock
 
-import transaction
+from transaction.interfaces import IDataManager
+from transaction.interfaces import TransactionFailedError
+from zope.interface import implementer
 
-from . import TM
+from .TM import TM
 from .TM import Surrogate
 
 
+LOG = logging.getLogger('Products.ZSQLMethods')
 thunk_lock = allocate_lock()
 
 
-class THUNKED_TM(TM.TM):
+@implementer(IDataManager)
+class THUNKED_TM(TM):
     """A big heavy hammer for handling non-thread safe DAs
     """
 
     def _register(self):
         if not self._registered:
             thunk_lock.acquire()
+
             try:
-                transaction.get().register(Surrogate(self))
-                self._begin()
-            except Exception:
-                thunk_lock.release()
+                self.transaction_manager.get().join(Surrogate(self))
+            except TransactionFailedError:
+                LOG.error('Failed to join transaction: ', exc_info=True)
+                # No need to raise here, the transaction is already
+                # broken as a whole
+            except ValueError:
+                LOG.error('Failed to join transaction: ', exc_info=True)
+                # Raising here, the transaction is in an invalid state
                 raise
             else:
+                self._begin()
                 self._registered = 1
+            finally:
+                thunk_lock.release()
 
     def tpc_finish(self, *ignored):
         if self._registered:

--- a/src/Shared/DC/ZRDB/TM.py
+++ b/src/Shared/DC/ZRDB/TM.py
@@ -38,7 +38,7 @@ class TM:
     def _register(self):
         if not self._registered:
             try:
-                transaction.get().register(Surrogate(self))
+                transaction.get().join(self)
                 self._begin()
                 self._registered = 1
                 self._finalize = 0

--- a/src/Shared/DC/ZRDB/TM.py
+++ b/src/Shared/DC/ZRDB/TM.py
@@ -12,10 +12,18 @@
 ##############################################################################
 """Provide support for linking an external transaction manager with Zope's
 """
+import logging
 
 import transaction
+from transaction.interfaces import IDataManager
+from transaction.interfaces import TransactionFailedError
+from zope.interface import implementer
 
 
+LOG = logging.getLogger('Products.ZSQLMethods')
+
+
+@implementer(IDataManager)
 class TM:
     """Mix-in class that provides transaction management support
 
@@ -32,18 +40,29 @@ class TM:
 
     _registered = None
 
+    def __init__(self):
+        # Use the default thread transaction manager.
+        self.transaction_manager = transaction.manager
+
     def _begin(self):
         pass
 
     def _register(self):
         if not self._registered:
             try:
-                transaction.get().join(self)
+                self.transaction_manager.get().join(Surrogate(self))
+            except TransactionFailedError:
+                LOG.error('Failed to join transaction: ', exc_info=True)
+                # No need to raise here, the transaction is already
+                # broken as a whole
+            except ValueError:
+                LOG.error('Failed to join transaction: ', exc_info=True)
+                # Raising here, the transaction is in an invalid state
+                raise
+            else:
                 self._begin()
                 self._registered = 1
                 self._finalize = 0
-            except Exception:
-                pass
 
     def tpc_begin(self, *ignored):
         pass

--- a/src/Shared/DC/ZRDB/TM.py
+++ b/src/Shared/DC/ZRDB/TM.py
@@ -39,10 +39,7 @@ class TM:
     """
 
     _registered = None
-
-    def __init__(self):
-        # Use the default thread transaction manager.
-        self.transaction_manager = transaction.manager
+    transaction_manager = transaction.manager
 
     def _begin(self):
         pass

--- a/src/Shared/DC/ZRDB/TM.py
+++ b/src/Shared/DC/ZRDB/TM.py
@@ -47,7 +47,7 @@ class TM:
     def _register(self):
         if not self._registered:
             try:
-                self.transaction_manager.get().join(Surrogate(self))
+                self.transaction_manager.get().join(self)
             except TransactionFailedError:
                 LOG.error('Failed to join transaction: ', exc_info=True)
                 # No need to raise here, the transaction is already
@@ -83,6 +83,8 @@ class TM:
             finally:
                 self._registered = 0
 
+    __inform_commit__ = tpc_finish
+
     def abort(self, *ignored):
         try:
             self._abort()
@@ -90,6 +92,7 @@ class TM:
             self._registered = 0
 
     tpc_abort = abort
+    __inform_abort__ = abort
 
     # Most DA's talking to RDBMS systems do not care about commit order, so
     # return a constant. Must be a string according to ITransactionManager.

--- a/src/Shared/DC/ZRDB/tests/testTHUNK.py
+++ b/src/Shared/DC/ZRDB/tests/testTHUNK.py
@@ -19,8 +19,8 @@ from unittest import makeSuite
 class TestTM(TestCase):
 
     def _getTargetClass(self):
-        from ..TM import TM
-        return TM
+        from ..THUNK import THUNKED_TM
+        return THUNKED_TM
 
     def _makeOne(self):
         return self._getTargetClass()()


### PR DESCRIPTION
`ITransaction` no longer has a method `register()`, the intended way to
register a component in the current transaction seems to be `join()`. This
does not immediately fail due to the unqualified `except` clause that
hides this error, but the effect is that `TM` objects are no longer
correctly rolled back on transaction abort.

I guess this also makes the class `Surrogate` superfluous, but I'm not deep enough in the code to be sure about this. Also, the unqualified `except` should probably be rewritten so it only catches expected errors instead of hiding such surprises. But I do not know what the expected errors here are supposed to be.