### PR TITLE
Fix linting issues

### DIFF
--- a/src/Shared/DC/ZRDB/tests/testArgs.py
+++ b/src/Shared/DC/ZRDB/tests/testArgs.py
@@ -56,7 +56,7 @@ class TestArgs(TestCase):
         args = self._makeOne({'arg1': {'type': 'string', 'default': 'n/a'}},
                              ['arg1'])
         self.assertIn('arg1', args)
-        self.assertTrue(args.has_key('arg1'))  # NOQA: flake8: W601
+        self.assertTrue('arg1' in args)
         self.assertDictEqual(args['arg1'],
                              {'default': 'n/a', 'type': 'string'})
         self.assertEqual(args.keys(), ['arg1'])

--- a/tox.ini
+++ b/tox.ini
@@ -40,8 +40,8 @@ commands_pre =
     mkdir -p {toxinidir}/parts/lint
 commands =
     isort --check-only --diff --recursive {toxinidir}/src setup.py
-    - flake8 --format=html src tests setup.py
-    flake8 src tests setup.py
+    - flake8 --format=html src setup.py
+    flake8 src setup.py
 deps =
     isort
     flake8


### PR DESCRIPTION
... which arise with the new flake8 version.

`tests` is no longer a valid flake8 param, as it is no top level
directory.

As it is a subfolder of the `src` folder, it gets linted anyway.

Also, `has_key` is deprecated and should be replaced by `in`.

modified:   tox.ini
modified:   src/Shared/DC/ZRDB/tests/testArgs.py