### PR TITLE
ZMI: monotonized paging buttons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.11 (unreleaased)
 ------------------
 
+- Improve pagination and search result display on the ZMI `Test` tab
+  (`#28 <https://github.com/zopefoundation/Products.ZSQLMethods/pull/28>`_)
+
 
 3.10 (2020-07-14)
 -----------------

--- a/src/Shared/DC/ZRDB/dtml/advanced.dtml
+++ b/src/Shared/DC/ZRDB/dtml/advanced.dtml
@@ -14,9 +14,8 @@
       <label for="connection_hook"
              class="form-label col-sm-3 col-xl-2">Connection Hook</label>
       <div class=" col-sm-9 col-xl-10">
-          <input type="text" class="form-control" name="connection_hook"
-                 id="connection_hook" size="40"
-				 value="<dtml-var connection_hook null="" missing="" html_quote>"/>
+          <input type="text" class="form-control" name="connection_hook" id="connection_hook" 
+            value="<dtml-var connection_hook null="" missing="" html_quote>" />
       </div>
     </div> 
 

--- a/src/Shared/DC/ZRDB/dtml/connectionTestForm.dtml
+++ b/src/Shared/DC/ZRDB/dtml/connectionTestForm.dtml
@@ -61,7 +61,7 @@
           <dtml-let res="manage_test(query)"
                     res_size="_.len(res)">
 
-            <p class="zmi-form-title font-weight-bold">
+            <p id="query_results" class="zmi-form-title font-weight-bold">
                 <dtml-if "res_size == 0">
                   <span class="badge badge-danger">0</span>
                 <dtml-else>
@@ -72,24 +72,21 @@
 
             <dtml-in "res" size=num_rows start=query_start orphan=3>
               <dtml-if sequence-start>
-                <ul class="pagination">
+                <nav class="zmi-find-results nav row mb-3"><div class="col-6">
                   <dtml-if previous-sequence-size>
-                    <li class="page-item">
-                      <a class="page-link" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-previous-sequence-start-number;">
-                        <i class="fas fa-angle-double-left mr-2"></i> Previous <dtml-var previous-sequence-size> results
-                      </a>
-                    </li>
+                    <a class="btn btn-primary" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-previous-sequence-start-number;">
+                      <i class="fas fa-chevron-left mr-2"></i> Previous <dtml-var previous-sequence-size> results
+                    </a>
                   </dtml-if previous-sequence-size>
                   <dtml-if next-sequence-size>
-                    <li class="page-item">
-                      <a class="page-link" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-next-sequence-start-number;">
-                        Next <dtml-var next-sequence-size> results <i class="fas fa-angle-double-right ml-2"></i>
-                      </a>
-                    </li>
+                    </div><div class="col-6 text-right">
+                    <a class="btn btn-primary" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-next-sequence-start-number;">
+                      Next <dtml-var next-sequence-size> results <i class="fas fa-chevron-right ml-2"></i>
+                    </a>
                   </dtml-if next-sequence-size>
-                </ul>
+                </div></nav>
 
-                <table class="table table-sm table-responsive table-striped table-hover table-bordered mb-5">
+                <table class="table table-sm table-responsive table-striped table-hover table-bordered mb-3">
                   <thead>
                     <tr>
                       <dtml-in "res.names()">
@@ -97,8 +94,8 @@
                       </dtml-in>
                     </tr>
                   </thead>
-              </dtml-if sequence-start>
 
+              </dtml-if sequence-start>
 
               <tr>
                 <dtml-let rec=sequence-item>
@@ -111,22 +108,19 @@
               <dtml-if sequence-end>
                  </table>
 
-                <ul class="pagination">
+                <nav class="zmi-find-results nav row mb-3"><div class="col-6">
                   <dtml-if previous-sequence-size>
-                    <li class="page-item">
-                      <a class="page-link" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-previous-sequence-start-number;">
-                        <i class="fas fa-angle-double-left mr-2"></i> Previous <dtml-var previous-sequence-size> results
-                      </a>
-                    </li>
+                    <a class="btn btn-primary" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-previous-sequence-start-number;">
+                      <i class="fas fa-chevron-left mr-2"></i> Previous <dtml-var previous-sequence-size> results
+                    </a>
                   </dtml-if previous-sequence>
                   <dtml-if next-sequence>
-                    <li class="page-item">
-                      <a class="page-link" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-next-sequence-start-number;">
-                        Next <dtml-var next-sequence-size> results <i class="fas fa-angle-double-right ml-2"></i>
-                      </a>
-                    </li>
+                    </div><div class="col-6 text-right">
+                    <a class="btn btn-primary" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-next-sequence-start-number;">
+                      Next <dtml-var next-sequence-size> results <i class="fas fa-chevron-right ml-2"></i>
+                    </a>
                   </dtml-if next-sequence>
-                </ul>
+                </div></nav>
               </dtml-if sequence-end>
 
             <dtml-else>
@@ -161,5 +155,15 @@
   </dtml-let>
 
 </main>
+
+<dtml-if "REQUEST.get('query_start', None)">
+  <script>
+    //<!--
+    document.addEventListener("DOMContentLoaded", function(event) {
+      document.location.href="#query_results";
+    });
+    //-->
+  </script>
+</dtml-if>
 
 <dtml-var manage_page_footer>

--- a/src/Shared/DC/ZRDB/dtml/connectionTestForm.dtml
+++ b/src/Shared/DC/ZRDB/dtml/connectionTestForm.dtml
@@ -160,7 +160,8 @@
   <script>
     //<!--
     document.addEventListener("DOMContentLoaded", function(event) {
-      document.location.href="#query_results";
+      el = document.getElementById("query_results");
+      el.scrollIntoView();
     });
     //-->
   </script>

--- a/src/Shared/DC/ZRDB/dtml/test.dtml
+++ b/src/Shared/DC/ZRDB/dtml/test.dtml
@@ -104,7 +104,7 @@
             <dtml-let res="this().manage_zmi_test(REQUEST)"
                       res_size="_.len(res)">
 
-              <p class="zmi-form-title font-weight-bold">
+              <p id="query_results" class="zmi-form-title font-weight-bold">
                   <dtml-if "res_size == 0">
                     <span class="badge badge-danger">0</span>
                   <dtml-else>
@@ -121,24 +121,21 @@
 
               <dtml-in "res" size=num_rows start=query_start orphan=3>
                 <dtml-if sequence-start>
-                  <ul class="pagination">
+                  <nav class="zmi-find-results nav row mb-3"><div class="col-6">
                     <dtml-if previous-sequence-size>
-                      <li class="page-item">
-                        <a class="page-link" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-previous-sequence-start-number;">
-                          <i class="fas fa-angle-double-left mr-2"></i> Previous <dtml-var previous-sequence-size> results
+                        <a class="btn btn-primary" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-previous-sequence-start-number;">
+                          <i class="fas fa-chevron-left mr-2"></i> Previous <dtml-var previous-sequence-size> results
                         </a>
-                      </li>
                     </dtml-if previous-sequence-size>
                     <dtml-if next-sequence-size>
-                      <li class="page-item">
-                        <a class="page-link" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-next-sequence-start-number;">
-                          Next <dtml-var next-sequence-size> results <i class="fas fa-angle-double-right ml-2"></i>
+                        </div><div class="col-6 text-right">
+                        <a class="btn btn-primary" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-next-sequence-start-number;">
+                          Next <dtml-var next-sequence-size> results <i class="fas fa-chevron-right ml-2"></i>
                         </a>
-                      </li>
                     </dtml-if next-sequence-size>
-                  </ul>
+                  </div></nav>
 
-                  <table class="table table-sm table-responsive table-striped table-hover table-bordered mb-5">
+                  <table class="table table-sm table-responsive table-striped table-hover table-bordered mb-3">
                     <thead>
                     <tr>
                       <dtml-in "res.names()">
@@ -146,6 +143,7 @@
                       </dtml-in>
                     </tr>
                     </thead>
+
                 </dtml-if sequence-start>
 
                 <tr>
@@ -159,22 +157,19 @@
                 <dtml-if sequence-end>
                   </table>
 
-                  <ul class="pagination">
+                  <nav class="zmi-find-results nav row mb-5"><div class="col-6">
                     <dtml-if previous-sequence-size>
-                      <li class="page-item">
-                        <a class="page-link" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-previous-sequence-start-number;">
-                          <i class="fas fa-angle-double-left mr-2"></i> Previous <dtml-var previous-sequence-size> results
+                        <a class="btn btn-primary" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-previous-sequence-start-number;">
+                          <i class="fas fa-chevron-left mr-2"></i> Previous <dtml-var previous-sequence-size> results
                         </a>
-                      </li>
                     </dtml-if previous-sequence-size>
                     <dtml-if next-sequence-size>
-                      <li class="page-item">
-                        <a class="page-link" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-next-sequence-start-number;">
-                          Next <dtml-var next-sequence-size> results <i class="fas fa-angle-double-right ml-2"></i>
+                      </div><div class="col-6 text-right">
+                        <a class="btn btn-primary" href="&dtml-URL;&dtml-sequence-query;query_start=&dtml-next-sequence-start-number;">
+                          Next <dtml-var next-sequence-size> results <i class="fas fa-chevron-right ml-2"></i>
                         </a>
-                      </li>
                     </dtml-if next-sequence-size>
-                  </ul>
+                  </div></nav>
                 </dtml-if sequence-end>
 
               </dtml-in>
@@ -231,5 +226,15 @@
   </dtml-let>
 
 </main>
+
+<dtml-if "REQUEST.get('query_start',None)">
+  <script>
+    //<!--
+    document.addEventListener("DOMContentLoaded", function(event) { 
+      document.location.href="#query_results";
+    });
+    //-->
+  </script>
+</dtml-if>
 
 <dtml-var manage_page_footer>

--- a/src/Shared/DC/ZRDB/dtml/test.dtml
+++ b/src/Shared/DC/ZRDB/dtml/test.dtml
@@ -92,10 +92,9 @@
             The final query sent to the database may contain additional
             elements inserted automatically, such as a <em>LIMIT</em> clause.
           </p>
-          <textarea data-contenttype="sql"
-                    class="form-control code zmi-code col-sm-12"
-                    name="template:text" wrap="off" disabled="disabled"
-                    rows="4"><dtml-var "this().manage_zmi_test(REQUEST, src__=1)"></textarea>
+          <pre class="form-control code col-sm-12 bg-dark text-white small border-0"
+            name="template:text" data-contenttype="sql"
+            ><dtml-var "this().manage_zmi_test(REQUEST, src__=1)"></pre>
 
           <br clear="all"/><hr/>
 

--- a/src/Shared/DC/ZRDB/dtml/test.dtml
+++ b/src/Shared/DC/ZRDB/dtml/test.dtml
@@ -226,11 +226,12 @@
 
 </main>
 
-<dtml-if "REQUEST.get('query_start', None)">
+<dtml-if "REQUEST.get('query_start',None)">
   <script>
     //<!--
     document.addEventListener("DOMContentLoaded", function(event) { 
-      document.location.href="#query_results";
+      el = document.getElementById("query_results");
+      el.scrollIntoView();
     });
     //-->
   </script>

--- a/src/Shared/DC/ZRDB/dtml/test.dtml
+++ b/src/Shared/DC/ZRDB/dtml/test.dtml
@@ -226,7 +226,7 @@
 
 </main>
 
-<dtml-if "REQUEST.get('query_start',None)">
+<dtml-if "REQUEST.get('query_start', None)">
   <script>
     //<!--
     document.addEventListener("DOMContentLoaded", function(event) { 


### PR DESCRIPTION
hi @dataflake,
the paging buttons are monotonized now to the style used for history. Moreover a UX issue is fixed when paging through the database results (table stays in viewport)
Yesterday I did not see the discrepancy of the buttons styles; sorry for that incovenience,

![paging](https://user-images.githubusercontent.com/29705216/87463413-a0a2f800-c611-11ea-84b7-b6598f814443.png)

