### PR TITLE
Fix the error output of SQL Methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Zope 4 ZMI improvements for database connection test form
 
+- Fix the ``repr`` of SQL Methods
+
 
 3.11 (2020-07-15)
 ------------------

--- a/src/Shared/DC/ZRDB/DA.py
+++ b/src/Shared/DC/ZRDB/DA.py
@@ -39,6 +39,7 @@ from DocumentTemplate.security import RestrictedDTML
 from ExtensionClass import Base
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item
+from OFS.SimpleItem import PathReprProvider
 from Persistence import Persistent
 from webdav.Resource import Resource
 from zExceptions import BadRequest
@@ -203,7 +204,8 @@ class SQL(RestrictedDTML, Base, nvSQL):
     pass
 
 
-class DA(BaseQuery,
+class DA(PathReprProvider,
+         BaseQuery,
          Implicit,
          Persistent,
          RoleManager,

--- a/src/Shared/DC/ZRDB/tests/testDA.py
+++ b/src/Shared/DC/ZRDB/tests/testDA.py
@@ -102,6 +102,11 @@ class TestTM(unittest.TestCase):
         self.assertEqual(da.template_class, klass.template_class)
         self.assertEqual(da.connection_hook, 'foo')
 
+    def test_repr(self):
+        da = self._makeOne('test_id', 'Test Title', 'conn_id',
+                           'foo bar', '<dtml-var bar>')
+        self.assertEqual(da.__repr__(), '<DA at test_id>')
+
 
 DEFAULT_DAV_SOURCE = """\
 <dtml-comment>


### PR DESCRIPTION
When errors occur, Zope usually formats the object in question with the physical path. This somehow fails for ZSQLMethod in Zope4.

The error output uses `__repr__()`, which in Zope2 was inherited from SimpleItem.Item, which in turn pulls in `SimpleItem.PathReprProvider`.

This inheritance pattern does not work in the same way in Python3, losing PathReprProvider in DA. Adding it there, at the very first position, yields the correct output.

Test this with:

    >>> from Products.ZSQLMethods.SQL import SQL
    >>> x = SQL('a', 'a', 'a', '', 'select * from data')
    >>> repr(x)
    '<SQL at a>'
