### PR TITLE
ZMII: fixed connection select list

### DIFF
--- a/src/Products/ZSQLMethods/dtml/edit.dtml
+++ b/src/Products/ZSQLMethods/dtml/edit.dtml
@@ -20,8 +20,8 @@
                class="form-label col-sm-3 col-md-2">Connection Id</label>
         <div class="col-sm-9 col-md-10">
           <select class="form-control" name="connection_id">
+            <option value=""> -- No database adapter selected -- </option>
             <dtml-in SQLConnectionIDs>
-               <option value=""> -- No database adapter selected -- </option>
                <option value="&dtml-sequence-item;"<dtml-if 
                 expr="connection_id==_vars['sequence-item']">
                 selected</dtml-if>>&dtml-sequence-key;</option>


### PR DESCRIPTION
Hi @dataflake,
i added a simple fix avoiding the iterative repetition of the database-connection list's _default option_ in the ZSQLMethod-Edit-GUI:

_Left: former status, Right: fixed_
![zmi_zsql_conn_select](https://user-images.githubusercontent.com/29705216/125664546-c0c9dec8-1d6a-4268-8ec5-2854b6331d78.gif)

Best regards
f