### PR TITLE
empty result provides a len of 0

### DIFF
--- a/src/Shared/DC/ZRDB/Results.py
+++ b/src/Shared/DC/ZRDB/Results.py
@@ -108,7 +108,10 @@ class Results:
         return self._data_dictionary
 
     def __len__(self):
-        return len(self._data)
+        if self._data == None:
+            return 0
+        else:
+            return len(self._data)
 
     def __getitem__(self, index):
         if index == self._index:

--- a/src/Shared/DC/ZRDB/Results.py
+++ b/src/Shared/DC/ZRDB/Results.py
@@ -108,7 +108,7 @@ class Results:
         return self._data_dictionary
 
     def __len__(self):
-        if self._data == None:
+        if self._data is None:
             return 0
         else:
             return len(self._data)


### PR DESCRIPTION
Hello @dataflake,
ZSQLMethods provides on UPDATE.SQL-calls (with SQLAlchemyDA) an empty resultset (NoneType) and then Results.py runs into an type error: 
`object of type 'NoneType' has no len() `
blocking an succesful execution of SQL-UPDATE. 
My code proposal makes sure, that the len() provides a valid value (0) in case the resultset is empty. 

_Comment: SQLAlchemyDA may not generate the expected result object, but I think it is more stable to cover this case in Products.ZSQLMethods._

Hope you like it.
f

Pic-1:  SQL-UPDATE returns a NoneType-result having no length
![ZSQLMethods0](https://user-images.githubusercontent.com/29705216/139599193-288da743-94e2-43c7-9c3b-e86d12436f4b.gif)

Pic-2: Effect of the code-fix (right)
![ZSQLMethods1](https://user-images.githubusercontent.com/29705216/139599199-32da1159-55f2-427b-86ed-0cada3f17a28.gif)


